### PR TITLE
Fix CI: typo and pin Julia to 1.11 for compatibility

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          version: '1.11'  # Pinned due to Julia 1.12 compatibility issues in upstream packages
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/src/lectures/lecture1.md
+++ b/docs/src/lectures/lecture1.md
@@ -560,7 +560,7 @@ end
 
 ![mass-spring-damper](../img/System2.png)
 
-Solving the system gives a plot of the 2 solved uknowns.
+Solving the system gives a plot of the 2 solved unknowns.
 
 ```@example l1 
 prob = ODEProblem(sys, [], (0, 10))


### PR DESCRIPTION
## Summary

- Fix typo "uknowns" → "unknowns" in `docs/src/lectures/lecture1.md:563`
- Pin Julia version to 1.11 in Documentation.yml workflow

## Problem

CI is currently failing on main due to:

1. **Spell check failure**: Typo "uknowns" at line 563 of lecture1.md
2. **Documentation build failure**: Julia 1.12 compatibility issues with upstream packages:
   - `UndefVarError: 'tmp' not defined in 'OrdinaryDiffEq'`
   - `UndefVarError: 'ForwardDiff' not defined in 'PreallocationTools'`

These upstream package bugs affect OrdinaryDiffEq, StochasticDiffEq, and SymbolicsPreallocationToolsExt when running on Julia 1.12.

## Solution

- Fixed the typo
- Pinned Julia version to 1.11 until upstream packages fix their Julia 1.12 compatibility

## Test plan

- [ ] Spell check should pass with the typo fix
- [ ] Documentation build should succeed with Julia 1.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)