### PR TITLE
Fix ModelingToolkit minimum version bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,4 +7,4 @@ version = "1.0.0"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
-ModelingToolkit = "8, 9"
+ModelingToolkit = "9"


### PR DESCRIPTION
## Summary

- Removed ModelingToolkit v8 from compat bounds since the codebase uses v9-only features

## Details

The main Project.toml had `ModelingToolkit = "8, 9"` in the compat section, but the lecture files use features that are only available in ModelingToolkit v9+:

- `t_nounits` and `D_nounits` - These were introduced in v9 as part of the units refactoring

Affected files that use v9-specific features:
- `docs/src/lectures/lecture1.jl`
- `docs/src/lectures/lecture2.jl`
- `docs/src/lectures/run_away_train_hydraulic.jl`

Note: The `docs/Project.toml` already correctly specifies `ModelingToolkit = "9"`.

## Test Plan

- [x] Verified lecture files use `t_nounits` and `D_nounits`
- [x] Confirmed these features were introduced in v9 per ModelingToolkit NEWS.md
- [ ] CI should pass with the updated bounds

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)