### PR TITLE
Add ExplicitImports.jl tests for import hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,3 +8,10 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 ModelingToolkit = "9"
+
+[extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ExplicitImports", "Test"]

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using ModelingToolkitCourse
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(ModelingToolkitCourse) === nothing
+    @test check_no_stale_explicit_imports(ModelingToolkitCourse) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,7 @@
+using Test
+
+@testset "ModelingToolkitCourse.jl" begin
+    @testset "Explicit Imports" begin
+        include("explicit_imports.jl")
+    end
+end


### PR DESCRIPTION
## Summary
- Added ExplicitImports.jl test suite to verify no implicit imports
- Added ExplicitImports.jl test suite to verify no stale explicit imports  
- Moved ExplicitImports dependency to test dependencies in Project.toml
- Updated test/runtests.jl to include explicit imports tests

## Test Results
All tests pass successfully. The package is currently clean with no import issues detected.

## What are ExplicitImports tests?

ExplicitImports.jl tests ensure:
1. **No implicit imports**: All names used from dependencies are explicitly imported
2. **No stale imports**: No unused imports remain in the code

This prevents issues where code accidentally relies on transitive dependencies or uses names that aren't actually imported.

## Test Output
```
Test Summary:            | Pass  Total  Time
ModelingToolkitCourse.jl |    2      2  2.5s
     Testing ModelingToolkitCourse tests passed
```

cc: @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)